### PR TITLE
Use a List for ckan.extra_resource_fields

### DIFF
--- a/ckanext/resourcedictionary/plugin.py
+++ b/ckanext/resourcedictionary/plugin.py
@@ -17,14 +17,15 @@ class ResourcedictionaryPlugin(plugins.SingletonPlugin):
     def update_config(self, config_):
         toolkit.add_template_directory(config_, 'templates')
         toolkit.add_public_directory(config_, 'public')
-        toolkit.add_resource('assets',
-                             'resourcedictionary')
+        toolkit.add_resource('assets', 'resourcedictionary')
 
         # Add `dictionary_fields` resource extra field in config
         # in order to add resource dictionary fields in SOLR index
-        config_[u'ckan.extra_resource_fields'] = u'dictionary_fields ' \
-                                                 u'dictionary_labels ' \
-                                                 u'dictionary_notes'
+        config_['ckan.extra_resource_fields'] = [
+            'dictionary_fields',
+            'dictionary_labels',
+            'dictionary_notes'
+            ]
 
     # IBlueprint
 


### PR DESCRIPTION

This pull request includes changes to the `ResourcedictionaryPlugin` class in the `ckanext/resourcedictionary/plugin.py` file to improve code readability and configuration handling. The most important changes include reformatting the `add_resource` method call and modifying the `ckan.extra_resource_fields` configuration setting to use a list instead of a concatenated string.

Improvements to code readability and configuration handling:

* `ckanext/resourcedictionary/plugin.py`: Changed the `ckan.extra_resource_fields` configuration setting to use a list for better readability and maintainability.

## Info about the bug:
When invoking the `resource_search` action via the CKAN API with the `ckanext-resourcedictionary` extension enabled, a `TypeError` occurs in `model/resource.py`due to improper handling of the `ckan.extra_resource_fields` configuration.
https://github.com/mjanez/ckan/blob/7e5f6a8fee630a912d4d4e442d9f3bf9c612f91a/ckan/model/resource.py#L149-L169

**Error Traceback:**

```log
2024-10-01 17:14:58,768 INFO  [ckan.model.resource] extra_columns: dictionary_fields dictionary_labels dictionary_notes
2024-10-01 17:14:58,769 ERROR [ckan.views.api] can only concatenate list (not "str") to list
Traceback (most recent call last):
  File "/srv/app/src/ckan/ckan/config/middleware/../../views/api.py", line 285, in action
    result = function(context, request_data)
  File "/srv/app/src/ckan/ckan/logic/__init__.py", line 580, in wrapped
    result = _action(context, data_dict, **kw)
  File "/srv/app/src/ckan/ckan/logic/__init__.py", line 681, in wrapper
    return action(context, data_dict)
  File "/srv/app/src/ckan/ckan/logic/action/get.py", line 2129, in resource_search
    resource_fields = model.Resource.get_columns()
  File "/srv/app/src/ckan/ckan/model/resource.py", line 154, in get_columns
    return CORE_RESOURCE_COLUMNS + cls.get_extra_columns()
TypeError: can only concatenate list (not "str") to list
```

**Steps to Reproduce:**

1. Using an extension that adds extra fields in the `update_config` method:

   ```python
   config_['ckan.extra_resource_fields'] = 'dictionary_fields ' \
                                            'dictionary_labels ' \
                                            'dictionary_notes'
   ```

3. Invoke the `resource_search` action via the API (`{{ckan_site_url}}/api/3/action/resource_search?query=size:0`.
4. The error occurs due to the concatenation of a list and a string.